### PR TITLE
Optimize print and remove using print declaration

### DIFF
--- a/core/utility_functions.hpp
+++ b/core/utility_functions.hpp
@@ -55,7 +55,7 @@ inline void prints_err() {
 */
 template<class... Args>
 inline void print(Args&&... variants) {
-	std::cout << S_TO_STRING(variants...) << '\n';
+	S_WRITE_INTO_STREAM(std::cout, variants..., '\n');
 }
 
 /**
@@ -63,7 +63,7 @@ inline void print(Args&&... variants) {
 */
 template<class... Args>
 inline void print_err(Args&&... variants) {
-	std::cerr << S_TO_STRING(variants...) << '\n';
+	S_WRITE_INTO_STREAM(std::cerr, variants..., '\n');
 }
 
 
@@ -72,7 +72,7 @@ inline void print_err(Args&&... variants) {
 */
 template<class... Args>
 inline void prints(Args&&... variants) {
-	std::cout << S_TO_STRINGS(variants...) << '\n';
+	S_WRITE_INTO_STREAMS(std::cout, variants..., '\n');
 }
 
 /**
@@ -80,7 +80,7 @@ inline void prints(Args&&... variants) {
 */
 template<class... Args>
 inline void prints_err(const Args&... variants) {
-	std::cerr << S_TO_STRINGS(variants...) << '\n';
+	S_WRITE_INTO_STREAMS(std::cerr, variants..., '\n');
 }
 
 enum TextModifier {

--- a/tests/base_tests.cpp
+++ b/tests/base_tests.cpp
@@ -4,7 +4,6 @@
 #include <memory>
 
 using namespace Toof::Tests;
-using Toof::UtilityFunctions::print;
 
 bool SuccessTest::_test() {
 	TEST_CASE(true); // Should not fail
@@ -19,7 +18,7 @@ bool FailTest::_test() {
 void Test::_test_fail(const String &message) {
 	if (message == "")
 		return;
-	print(message);
+	PRINT_LINE(message);
 }
 
 bool Test::run_test() {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -7,7 +7,6 @@
 #include <cstring>
 
 using namespace Toof::Tests;
-using Toof::UtilityFunctions::print;
 
 std::unordered_map<Toof::String, std::unique_ptr<Test>> tests;
 
@@ -53,9 +52,9 @@ int main(const int argc, const char **argv) {
 	TestRun run = try_test_run(argv[1]);
 	if (run == TEST_RUN_UNKNOWN)
 		PRINT_RETURN("No test ran.", EXIT_FAILURE)
-	else if (run == TEST_RUN_SUCCESS)
-		print("Test ran succesfully.");
-	else
+	else if (run == TEST_RUN_SUCCESS) {
+		PRINT_LINE("Test ran succesfully.");
+	} else
 		PRINT_RETURN("Test failed.", EXIT_FAILURE);
 
 	return EXIT_SUCCESS;


### PR DESCRIPTION
Optimizes the UtilityFunctions print, prints, print_err, and prints_err function by using S_WRITE_INTO_STREAM(S).
Removes `using Toof::UtilityFunctions::print` as well and uses `PRINT_LINE` instead.