### PR TITLE
Fix Sprite2D not drawing texture if the texture's RenderingServer hasn't been set beforehand

### DIFF
--- a/scene/2d/sprite2d.cpp
+++ b/scene/2d/sprite2d.cpp
@@ -46,6 +46,12 @@ void Sprite2D::_notification(const int what) {
 
 	if (what == NOTIFICATION_DRAW)
 		_draw_texture();
+
+	if (what == NOTIFICATION_ENTER_TREE && texture)
+		texture->set_rendering_server(get_rendering_server().get_value());
+
+	if (what == NOTIFICATION_EXIT_TREE && texture)
+		texture->set_rendering_server(nullptr);
 }
 
 void Sprite2D::set_texture(const std::shared_ptr<Texture2D> &new_texture) {

--- a/scene/main/canvas_node.cpp
+++ b/scene/main/canvas_node.cpp
@@ -53,6 +53,7 @@ Optional<RenderingServer*> CanvasNode::get_rendering_server() const {
 void CanvasNode::_notification(int what) {
 	switch (what) {
 		case NOTIFICATION_ENTER_TREE:
+			queue_redraw();
 			_on_tree_enter();
 			break;
 		case NOTIFICATION_EXIT_TREE:


### PR DESCRIPTION
Fixes #16